### PR TITLE
Create I am dumb.md

### DIFF
--- a/I am dumb.md
+++ b/I am dumb.md
@@ -1,0 +1,13 @@
+# I am dumb
+
+If a narc gets *too high*—whether on their own delusions, ego, or something else—they can get **reckless**. When they feel invincible, they might:  
+
+1. **Overplay Their Hand** – They start making outrageous claims, taking credit for things they clearly didn’t do, or pushing their manipulation too far. Eventually, they expose themselves.  
+2. **Self-Destruct** – Their own arrogance can trip them up. They start believing their own lies so much that they lose control, ruin relationships, or even sabotage themselves.  
+3. **Escalate Their Manipulation** – If they sense they’re losing control over people, they might double down—gaslighting harder, throwing tantrums, or trying to provoke reactions just to feel powerful again.  
+4. **Publicly Humiliate Themselves** – When they get too cocky, they stop being careful. They might say or do something that finally makes others see them for what they are.  
+5. **Turn on Their Own Allies** – When they’re too high on themselves, they stop seeing their enablers as useful. They start betraying the very people who backed them up.  
+
+If you’re dealing with a narc in this state, best move? **Step back and watch them implode.** They always do. It’s just a matter of time.  
+
+What’s the narc in your life up to now? Are they about to crash and burn, or still riding their delusional high?


### PR DESCRIPTION
```markdown
# I am dumb

If a narc gets *too high*—whether on their own delusions, ego, or something else—they can get **reckless**. When they feel invincible, they might:  

1. **Overplay Their Hand** – They start making outrageous claims, taking credit for things they clearly didn’t do, or pushing their manipulation too far. Eventually, they expose themselves.  
2. **Self-Destruct** – Their own arrogance can trip them up. They start believing their own lies so much that they lose control, ruin relationships, or even sabotage themselves.  
3. **Escalate Their Manipulation** – If they sense they’re losing control over people, they might double down—gaslighting harder, throwing tantrums, or trying to provoke reactions just to feel powerful again.  
4. **Publicly Humiliate Themselves** – When they get too cocky, they stop being careful. They might say or do something that finally makes others see them for what they are.  
5. **Turn on Their Own Allies** – When they’re too high on themselves, they stop seeing their enablers as useful. They start betraying the very people who backed them up.  

If you’re dealing with a narc in this state, best move? **Step back and watch them implode.** They always do. It’s just a matter of time.  

What’s the narc in your life up to now? Are they about to crash and burn, or still riding their delusional high?
```