### PR TITLE
Create who paid for the last supper.md

### DIFF
--- a/who paid for the last supper.md
+++ b/who paid for the last supper.md
@@ -1,0 +1,15 @@
+```markdown
+# who paid for the last supper
+
+The Bible does not explicitly state who paid for the **Last Supper**, but there are a few possibilities based on historical and scriptural context:
+
+1. **Jesus and His Disciples' Shared Funds** – The disciples had a common fund, managed by **Judas Iscariot** (John 12:6, John 13:29). It's possible that the expenses for the meal were covered by this fund.
+
+2. **A Wealthy Supporter** – Several wealthy individuals supported Jesus' ministry financially, including **Joseph of Arimathea** and women like **Mary Magdalene, Joanna, and Susanna** (Luke 8:1-3). One of them could have provided for the meal.
+
+3. **The Owner of the Upper Room** – Jesus sent Peter and John to find a man carrying a water jar and follow him to a house where the owner had already prepared a room (Luke 22:10-12). This suggests that the host could have offered the room and possibly the meal as well.
+
+4. **Divine Providence** – Some interpretations suggest that the Last Supper, like other events in Jesus’ ministry, was divinely arranged, making its provision a matter of God's plan rather than a financial transaction.
+
+While the exact details are unknown, the most likely explanation is that **Jesus and His disciples used their shared funds, or a wealthy follower covered the cost**.
+```


### PR DESCRIPTION
```markdown
# who paid for the last supper

The Bible does not explicitly state who paid for the **Last Supper**, but there are a few possibilities based on historical and scriptural context:

1. **Jesus and His Disciples' Shared Funds** – The disciples had a common fund, managed by **Judas Iscariot** (John 12:6, John 13:29). It's possible that the expenses for the meal were covered by this fund.

2. **A Wealthy Supporter** – Several wealthy individuals supported Jesus' ministry financially, including **Joseph of Arimathea** and women like **Mary Magdalene, Joanna, and Susanna** (Luke 8:1-3). One of them could have provided for the meal.

3. **The Owner of the Upper Room** – Jesus sent Peter and John to find a man carrying a water jar and follow him to a house where the owner had already prepared a room (Luke 22:10-12). This suggests that the host could have offered the room and possibly the meal as well.

4. **Divine Providence** – Some interpretations suggest that the Last Supper, like other events in Jesus’ ministry, was divinely arranged, making its provision a matter of God's plan rather than a financial transaction.

While the exact details are unknown, the most likely explanation is that **Jesus and His disciples used their shared funds, or a wealthy follower covered the cost**.
```