### PR TITLE
Update who paid for the last supper.md

### DIFF
--- a/who paid for the last supper.md
+++ b/who paid for the last supper.md
@@ -1,6 +1,6 @@
-```markdown
 # who paid for the last supper
 
+```markdown
 The Bible does not explicitly state who paid for the **Last Supper**, but there are a few possibilities based on historical and scriptural context:
 
 1. **Jesus and His Disciples' Shared Funds** – The disciples had a common fund, managed by **Judas Iscariot** (John 12:6, John 13:29). It's possible that the expenses for the meal were covered by this fund.
@@ -13,3 +13,25 @@ The Bible does not explicitly state who paid for the **Last Supper**, but there 
 
 While the exact details are unknown, the most likely explanation is that **Jesus and His disciples used their shared funds, or a wealthy follower covered the cost**.
 ```
+
+##  jesus got killed beacuse they didnt pay the meal
+
+```markdown
+No, Jesus was not killed because they didn’t pay for the Last Supper. His crucifixion was the result of political and religious tensions between Him, the Jewish authorities, and the Roman government.
+
+### **Why Was Jesus Crucified?**
+1. **Religious Leaders’ Accusations** – The Jewish religious leaders saw Jesus as a threat because He challenged their authority, called out their hypocrisy, and claimed divine status (Matthew 26:63-65, John 10:30-33).
+
+2. **Roman Involvement** – The Jewish leaders brought Jesus t`o **Pontius Pilate**, the Roman governor, accusing Him of claiming to be the "King of the Jews" (Luke 23:2-3). This was seen as a challenge to Roman rule.
+
+3. **Judas’ Betrayal** – One of Jesus' own disciples, **Judas Iscariot**, betrayed Him for 30 pieces of silver (Matthew 26:14-16). His betrayal led to Jesus' arrest.
+
+4. **Public Pressure & Crucifixion** – Pilate, though reluctant, gave in to the crowd’s demand to crucify Jesus, as they preferred to release Barabbas, a known criminal, instead (Matthew 27:20-26).
+
+### **What About the Last Supper Bill?**
+The idea that Jesus was crucified because He and His disciples didn’t pay for the Last Supper is not supported by any historical or biblical sources. If there had been a cost issue, it would have been a minor matter, not something leading to His execution.
+
+However, if you’re jokingly suggesting that **Jesus dined and dashed**, that would make for a dark humor conspiracy theory, but the reality is much deeper than that. His crucifixion was a result of political and religious power struggles, not an unpaid dinner tab!
+```
+
+## Jesus was not good at math, DUH


### PR DESCRIPTION
```markdown
# who paid for the last supper

```markdown
The Bible does not explicitly state who paid for the **Last Supper**, but there are a few possibilities based on historical and scriptural context:

1. **Jesus and His Disciples' Shared Funds** – The disciples had a common fund, managed by **Judas Iscariot** (John 12:6, John 13:29). It's possible that the expenses for the meal were covered by this fund.

2. **A Wealthy Supporter** – Several wealthy individuals supported Jesus' ministry financially, including **Joseph of Arimathea** and women like **Mary Magdalene, Joanna, and Susanna** (Luke 8:1-3). One of them could have provided for the meal.

3. **The Owner of the Upper Room** – Jesus sent Peter and John to find a man carrying a water jar and follow him to a house where the owner had already prepared a room (Luke 22:10-12). This suggests that the host could have offered the room and possibly the meal as well.

4. **Divine Providence** – Some interpretations suggest that the Last Supper, like other events in Jesus’ ministry, was divinely arranged, making its provision a matter of God's plan rather than a financial transaction.

While the exact details are unknown, the most likely explanation is that **Jesus and His disciples used their shared funds, or a wealthy follower covered the cost**.
```

##  jesus got killed beacuse they didnt pay the meal

```markdown
No, Jesus was not killed because they didn’t pay for the Last Supper. His crucifixion was the result of political and religious tensions between Him, the Jewish authorities, and the Roman government.

### **Why Was Jesus Crucified?**
1. **Religious Leaders’ Accusations** – The Jewish religious leaders saw Jesus as a threat because He challenged their authority, called out their hypocrisy, and claimed divine status (Matthew 26:63-65, John 10:30-33).

2. **Roman Involvement** – The Jewish leaders brought Jesus t`o **Pontius Pilate**, the Roman governor, accusing Him of claiming to be the "King of the Jews" (Luke 23:2-3). This was seen as a challenge to Roman rule.

3. **Judas’ Betrayal** – One of Jesus' own disciples, **Judas Iscariot**, betrayed Him for 30 pieces of silver (Matthew 26:14-16). His betrayal led to Jesus' arrest.

4. **Public Pressure & Crucifixion** – Pilate, though reluctant, gave in to the crowd’s demand to crucify Jesus, as they preferred to release Barabbas, a known criminal, instead (Matthew 27:20-26).

### **What About the Last Supper Bill?**
The idea that Jesus was crucified because He and His disciples didn’t pay for the Last Supper is not supported by any historical or biblical sources. If there had been a cost issue, it would have been a minor matter, not something leading to His execution.

However, if you’re jokingly suggesting that **Jesus dined and dashed**, that would make for a dark humor conspiracy theory, but the reality is much deeper than that. His crucifixion was a result of political and religious power struggles, not an unpaid dinner tab!
```

## Jesus was not good at math, DUH
```